### PR TITLE
Fix potential vulnerability in use of the rand.Seed

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -80,8 +79,7 @@ func main() {
 
 	loginError = WebAuthnError{Message: "Unable to login"}
 	registrationError = WebAuthnError{Message: "Error during registration"}
-
-	rand.Seed(time.Now().UnixNano())
+	util.RandInit()
 
 	users = make(map[string]u.User)
 	registrations = make(map[string]u.User)

--- a/util/util.go
+++ b/util/util.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
 	"net/http"
 	"regexp"
 
 	"github.com/duo-labs/webauthn/webauthn"
 	"github.com/gorilla/sessions"
+
+	crypto_rand "crypto/rand"
+	"encoding/binary"
+	math_rand "math/rand"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -83,11 +86,20 @@ func SaveWebauthnSession(session *sessions.Session, key string, sessionData *web
 	return nil
 }
 
+func RandInit() {
+	var b [8]byte
+	_, err := crypto_rand.Read(b[:])
+	if err != nil {
+		panic("cannot seed math/rand package with cryptographically secure random number generator")
+	}
+	math_rand.Seed(int64(binary.LittleEndian.Uint64(b[:])))
+}
+
 // Generate a random string of alpha characters of length n
 func RandStringBytesRmndr(n int) []byte {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+		b[i] = letterBytes[math_rand.Int63()%int64(len(letterBytes))]
 	}
 	return b
 }


### PR DESCRIPTION
According to webauthn spec. the challange needs to be hard to guess
otherwise the protocol is vulnerable to reply attack see:
https://www.w3.org/TR/webauthn-2/#sctn-cryptographic-challenges

> In order to prevent replay attacks, the challenges MUST contain
> enough entropy to make guessing them infeasible. Challenges
> SHOULD therefore be at least 16 bytes long.

Initating with the random seed with time makes it easy to guess after
a restart. The space of seeds can be quickly enumerated, because time
has lager resultion than nanosecods. See this more details:
https://github.com/Quiq/webauthn_proxy