### PR TITLE
Origin/fix mixed case username storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gorilla/sessions v1.2.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -37,5 +38,4 @@ require (
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ type Configuration struct {
 	UsernameRegex             string
 }
 
-type Credentials struct {
+type CredentialsConfiguration struct {
 	CookieSecrets []string          `yaml:"cookie_session_secrets"`
 	Credentials   map[string]string `yaml:"user_credentials"`
 }
@@ -99,7 +99,7 @@ func main() {
 
 	var err error
 	var credfile []byte
-	var credentials Credentials
+	var credentialsConfig CredentialsConfiguration
 	// Standard error messages
 	loginError = WebAuthnMessage{Message: "Unable to login"}
 	registrationError = WebAuthnMessage{Message: "Error during registration"}
@@ -145,7 +145,7 @@ func main() {
 	if credfile, err = os.ReadFile(credentialspath); err != nil {
 		logger.Fatalf("Unable to read credential file %s %v", credentialspath, err)
 	}
-	if err = yaml.Unmarshal(credfile, &credentials); err != nil {
+	if err = yaml.Unmarshal(credfile, &credentialsConfig); err != nil {
 		logger.Fatalf("Unable to parse YAML credential file %s %v", credentialspath, err)
 	}
 
@@ -161,7 +161,7 @@ func main() {
 		logger.Fatal("Invalid session hard timeout, must be > session soft timeout")
 	}
 
-	cookieSecrets = credentials.CookieSecrets
+	cookieSecrets = credentialsConfig.CookieSecrets
 	if len(cookieSecrets) == 0 {
 		logger.Warnf("You did not set any cookie_session_secrets in credentials.yml.")
 		logger.Warnf("So it will be dynamic and your cookie sessions will not persist proxy restart.")
@@ -171,7 +171,7 @@ func main() {
 		logger.Warnf("You did not set any valid cookie_session_secrets in credentials.yml.")
 		logger.Fatalf("Generate one using `-generate-secret` flag and add to credentials.yml.")
 	}
-	for username, credential := range credentials.Credentials {
+	for username, credential := range credentialsConfig.Credentials {
 		unmarshaledUser, err := u.UnmarshalUser(credential)
 		if err != nil {
 			logger.Fatalf("Error unmarshalling user credential %s: %s", username, err)


### PR DESCRIPTION
- usernames that were registered with uppercase characters are loaded via spf13/viper which converts them to lowercase, leading to startup error "Credentials for user myuser are designated for another one myUser"
- fix this by changing the parser for the credentials file back to gopkg.in/yaml.v3 which preserves casing
- this fix is an alternative to PR https://github.com/Quiq/webauthn_proxy/pull/9 and should be the 'proper' fix discussed in the pull request