### PR TITLE
Support for cookieDomain in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Otherwise, if you wanted it to work for any service under _example.com_, you cou
 | testMode | When set to **_true_**, users can authenticate immediately after registering. Useful for testing, but generally not safe for production. | false |
 | usernameRegex | Regex for validating usernames | ^.+$ |
 | cookieSecure | When set to **_true_**, enables the Secure flag for cookies. Useful when running behind a TLS reverse proxy. | false |
+| cookieDomain | The domain to be used for cookies. Useful when running WebAuthn Proxy for multiple subdomains. | Domain of the page the user is visiting |
 
 
 ## Thanks!

--- a/config/config.yml
+++ b/config/config.yml
@@ -40,6 +40,10 @@ rpOrigins:
 ## Basically, email addresses
 # usernameRegex: ^[A-Za-z0-9\-\_\.\@]+$
 
-## cookieSecure - When set to 'true', enables the Secure flag for cookies. 
+## cookieSecure - When set to 'true', enables the Secure flag for cookies.
 ## Useful when running behind a TLS reverse proxy.
 # cookieSecure: false
+
+## cookieDomain - The domain to be used for cookies.
+## Useful when running WebAuthn Proxy for multiple subdomains.
+# cookieDomain: example.com

--- a/util/util.go
+++ b/util/util.go
@@ -16,8 +16,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Placeholder for cookieSecure config value
+// Placeholder for cookieSecure and cookieDomain config values
 var CookieSecure bool = false
+var CookieDomain string = ""
 
 // Get "username" query param and validate against supplied regex
 func GetUsername(r *http.Request, regex string) (string, error) {
@@ -72,6 +73,7 @@ func SaveWebauthnSession(session *sessions.Session, key string, sessionData *web
 // ExpireWebauthnSession invalidate session by expiring cookie
 func ExpireWebauthnSession(session *sessions.Session, r *http.Request, w http.ResponseWriter) {
 	session.Options = &sessions.Options{
+		Domain:   CookieDomain,
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,


### PR DESCRIPTION
Hi! First of all, **thank you** so much for providing this amazing WebAuthn proxy 🙂 

This PR adds the possibility for the user to change the **domain of the cookies**. It can be very useful when you run WebAuthn Proxy for multiple subdomains.

For example, if `cookieDomain` is set to `example.com`, the cookies will be valid for `example.com` and all the `*.example.com` subdomains. This means that a user will be able to visit e.g. `login.example.com`, log in, and then be redirected to `admin.example.com` where they will be **already authenticated**. No need to login twice.

I hope this can be a good addition :) let me know what you think