### PR TITLE
Prevent logging of the generated cookie secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker run --rm -ti -p 8080:8080 -v /path/to/config:/opt/config:ro quiq/webauthn
 ```
 To generate cookie secret to add to `credentials.yml`:
 ```
-docker run --rm -ti quiq/webauthn_proxy:latest -generate-secret
+docker run --rm --log-driver=none quiq/webauthn_proxy:latest -generate-secret
 <secret>
 ```
 


### PR DESCRIPTION
First of all, **thank you** so much for providing this amazing WebAuthn proxy 🙂 

This simple PR is a small security improvement: adding `--log-driver=none` prevents logging the generated cookie secret to disk, as Docker does that by default. You can check this link for more information: https://docs.docker.com/reference/cli/docker/container/run/#log-driver

In addition, the `-ti` flags were not really needed there, as it's not an interactive command and it doesn't interact with the terminal, so I just removed them.

I hope this is useful :) let me know. Thanks in advance